### PR TITLE
Cambio en el namespace de tests de cuenta

### DIFF
--- a/Banco_VivesBank/Test/Producto/Cuenta/Controller/CuentaAdminControllerTest.cs
+++ b/Banco_VivesBank/Test/Producto/Cuenta/Controller/CuentaAdminControllerTest.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 
-namespace Banco_VivesBank.Test.Producto.Cuenta.Controller;
+namespace Test.Producto.Cuenta.Controller;
 
 public class CuentaAdminControllerTests
 {
@@ -57,7 +57,7 @@ public class CuentaAdminControllerTests
     public async Task GetAllNotFound()
     {
         _cuentaService.Setup(service => service.GetAllAsync(It.IsAny<BigInteger?>(), It.IsAny<BigInteger?>(), It.IsAny<string>(), It.IsAny<PageRequest>()))
-            .ThrowsAsync(new CuentaNoEncontradaException("No se han encontrado las cuentas."));
+            .ThrowsAsync(new CuentaNotFoundException("No se han encontrado las cuentas."));
 
         var result = await _cuentaController.Getall(It.IsAny<BigInteger?>(), It.IsAny<BigInteger?>(), It.IsAny<string>(), It.IsAny<int>());
         Assert.That(result.Result, Is.TypeOf<ObjectResult>());
@@ -125,7 +125,7 @@ public class CuentaAdminControllerTests
     public async Task GetAllByClienteGuidNotFound()
     {
         _cuentaService.Setup(service => service.GetByClientGuidAsync("cliente-Guid"))
-            .ThrowsAsync(new CuentaNoEncontradaException("No se han encontrado las cuentas del cliente."));
+            .ThrowsAsync(new CuentaNotFoundException("No se han encontrado las cuentas del cliente."));
 
         var result = await _cuentaController.GetAllByClientGuid("clienteGuid");
         Assert.That(result.Result, Is.TypeOf<ObjectResult>());
@@ -192,7 +192,7 @@ public class CuentaAdminControllerTests
     public async Task GetByGuidNotFound()
     {
         _cuentaService.Setup(service => service.GetByGuidAsync("guid"))
-            .ThrowsAsync(new CuentaNoEncontradaException("No se ha encontrado la cuenta."));
+            .ThrowsAsync(new CuentaNotFoundException("No se ha encontrado la cuenta."));
 
         var result = await _cuentaController.GetByGuid("guid");
         Assert.That(result.Result, Is.TypeOf<ObjectResult>());
@@ -259,7 +259,7 @@ public class CuentaAdminControllerTests
     public async Task GetByIbanNotFound()
     {
         _cuentaService.Setup(service => service.GetByIbanAsync("iban"))
-            .ThrowsAsync(new CuentaNoEncontradaException("No se ha encontrado la cuenta."));
+            .ThrowsAsync(new CuentaNotFoundException("No se ha encontrado la cuenta."));
 
         var result = await _cuentaController.GetByIban("iban");
         Assert.That(result.Result, Is.TypeOf<ObjectResult>());
@@ -316,7 +316,7 @@ public class CuentaAdminControllerTests
     public async Task DeleteNotFound()
     {
         _cuentaService.Setup(service => service.DeleteAdminAsync("guid"))
-            .ThrowsAsync(new CuentaNoEncontradaException("No se ha encontrado la cuenta."));
+            .ThrowsAsync(new CuentaNotFoundException("No se ha encontrado la cuenta."));
 
         var result = await _cuentaController.Delete("guid");
         Assert.That(result.Result, Is.TypeOf<ObjectResult>());

--- a/Banco_VivesBank/Test/Producto/Cuenta/Mapper/CuentaMapperTest.cs
+++ b/Banco_VivesBank/Test/Producto/Cuenta/Mapper/CuentaMapperTest.cs
@@ -5,7 +5,7 @@ using Banco_VivesBank.Producto.Cuenta.Mappers;
 using Banco_VivesBank.Producto.Tarjeta.Dto;
 using NUnit.Framework;
 
-namespace Banco_VivesBank.Test.Producto.Cuenta;
+namespace Test.Producto.Cuenta;
 
 [TestFixture]
 public class CuentaMapperTest

--- a/Banco_VivesBank/Test/Producto/Cuenta/Services/CuentaServiceTest.cs
+++ b/Banco_VivesBank/Test/Producto/Cuenta/Services/CuentaServiceTest.cs
@@ -31,7 +31,7 @@ using BigInteger = System.Numerics.BigInteger;
 using Direccion = Banco_VivesBank.Cliente.Models.Direccion;
 using Role = Banco_VivesBank.User.Models.Role;
 
-namespace Banco_VivesBank.Test.Producto.Cuenta.Services;
+namespace Test.Producto.Cuenta.Services;
 
 [TestFixture]
 [TestOf(typeof(CuentaService))]


### PR DESCRIPTION
Cambio en el namespace de tests de cuenta.

Antes estaba como Banco_VivesBank.Test...... y ahora como Test......... El namespace estaba mal