### PR TITLE
Creación de Repositorio de Domiciliaciones

### DIFF
--- a/Banco_VivesBank/Banco_VivesBank/Movimientos/Repositories/DomiciliacionRepository.cs
+++ b/Banco_VivesBank/Banco_VivesBank/Movimientos/Repositories/DomiciliacionRepository.cs
@@ -1,0 +1,82 @@
+﻿using Banco_VivesBank.Movimientos.Database;
+using Banco_VivesBank.Movimientos.Models;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+
+namespace Banco_VivesBank.Movimientos.Repositories;
+
+public class DomiciliacionRepository : IDomiciliacionRepository
+{
+    private readonly IMongoCollection<Domiciliacion> _collection;
+    private readonly ILogger<DomiciliacionRepository> _logger;
+
+    public DomiciliacionRepository(IOptions<MovimientosMongoConfig> movimientosDatabaseSettings,
+        ILogger<DomiciliacionRepository> logger)
+    {
+        var client = new MongoClient(movimientosDatabaseSettings.Value.ConnectionString);
+        var database = client.GetDatabase(movimientosDatabaseSettings.Value.DatabaseName);
+        _collection = database.GetCollection<Domiciliacion>(movimientosDatabaseSettings.Value.DomiciliacionesCollectionName);
+        _logger = logger;
+    }
+
+
+    public async Task<List<Domiciliacion>> GetAllDomiciliacionesAsync()
+    {
+        _logger.LogInformation("Getting all direct debits from the database.");
+        return await _collection.FindAsync(_ => true).Result.ToListAsync();
+    }
+
+    public async Task<List<Domiciliacion>> GetAllDomiciliacionesActivasAsync()
+    {
+        _logger.LogInformation("Getting all active direct debits from the database.");
+        return await _collection.FindAsync(d => d.Activa).Result.ToListAsync();
+    }
+
+    public async Task<Domiciliacion?> GetDomiciliacionByIdAsync(string id)
+    {
+        _logger.LogInformation($"Getting direct debit with id {id} from the database.");
+        return await _collection.Find(d => d.Id == id).FirstOrDefaultAsync();
+    }
+    
+    public async Task<Domiciliacion?> GetDomiciliacionByGuidAsync(string guid)
+    {
+        _logger.LogInformation($"Getting direct debit with guid {guid} from the database.");
+        return await _collection.Find(d => d.Guid == guid).FirstOrDefaultAsync();
+    }
+    
+    public async Task<Domiciliacion> AddDomiciliacionAsync(Domiciliacion domiciliacion)
+    {
+        _logger.LogInformation($"Adding a new direct debit to the database: {domiciliacion}");
+        await _collection.InsertOneAsync(domiciliacion);
+        return domiciliacion;
+    }
+
+    public async Task<Domiciliacion> UpdateDomiciliacionAsync(string id, Domiciliacion domiciliacion)
+    {
+        _logger.LogInformation($"Updating direct debit with id {id} in the database.");
+        var updateResult = await _collection.FindOneAndReplaceAsync(
+            d => d.Id == id,
+            domiciliacion,
+            new FindOneAndReplaceOptions<Domiciliacion>{ ReturnDocument = ReturnDocument.After }
+        );
+        return updateResult;
+    }
+
+    public async Task<Domiciliacion> DeleteDomiciliacionAsync(string id)
+    {
+        _logger.LogInformation($"Deleting direct debit with id {id} from the database.");
+        var deletedDomiciliacion = await _collection.FindOneAndDeleteAsync(d => d.Id == id);
+        return deletedDomiciliacion;    }
+
+    public async Task<List<Domiciliacion>> GetDomiciliacionesActivasByClienteGiudAsync(string clienteGuid)
+    {            
+        _logger.LogInformation($"Getting active direct debits for client with guid {clienteGuid} from the database.");
+        return await _collection.FindAsync(d => d.ClienteGuid == clienteGuid && d.Activa).Result.ToListAsync();
+    }
+
+    public async Task<List<Domiciliacion>> GetDomiciliacionesByClientGuidAsync(string clientGuid)
+    {
+        _logger.LogInformation($"Getting direct debits for client with guid {clientGuid}.");
+        return await _collection.FindAsync(d => d.ClienteGuid == clientGuid).Result.ToListAsync();
+    }
+}

--- a/Banco_VivesBank/Banco_VivesBank/Movimientos/Repositories/IDomiciliacionRepository.cs
+++ b/Banco_VivesBank/Banco_VivesBank/Movimientos/Repositories/IDomiciliacionRepository.cs
@@ -1,0 +1,20 @@
+﻿using Banco_VivesBank.Movimientos.Models;
+
+namespace Banco_VivesBank.Movimientos.Repositories;
+
+public interface IDomiciliacionRepository
+{
+    Task<List<Domiciliacion>> GetAllDomiciliacionesAsync();
+    Task<List<Domiciliacion>> GetAllDomiciliacionesActivasAsync();
+    Task<Domiciliacion?> GetDomiciliacionByIdAsync(string id);
+    Task<Domiciliacion?> GetDomiciliacionByGuidAsync(string guid);
+    Task<Domiciliacion> AddDomiciliacionAsync(Domiciliacion domiciliacion);
+    Task<Domiciliacion> UpdateDomiciliacionAsync(string id, Domiciliacion domiciliacion);
+    Task<Domiciliacion> DeleteDomiciliacionAsync(string id);
+    Task<List<Domiciliacion>> GetDomiciliacionesActivasByClienteGiudAsync(string clienteGuid);
+    Task<List<Domiciliacion>> GetDomiciliacionesByClientGuidAsync(string clientGuid);
+
+
+
+    
+}

--- a/Banco_VivesBank/Banco_VivesBank/Program.cs
+++ b/Banco_VivesBank/Banco_VivesBank/Program.cs
@@ -7,6 +7,7 @@ using Banco_VivesBank.Database;
 using Banco_VivesBank.Frankfurter.Services;
 using Banco_VivesBank.GraphQL;
 using Banco_VivesBank.Movimientos.Database;
+using Banco_VivesBank.Movimientos.Repositories;
 using Banco_VivesBank.Movimientos.Scheduler;
 using Banco_VivesBank.Movimientos.Services.Domiciliaciones;
 using Banco_VivesBank.Movimientos.Services.Movimientos;
@@ -168,6 +169,9 @@ WebApplicationBuilder InitServices()
     myBuilder.Services.AddScoped<DomiciliacionScheduler>();
     myBuilder.Services.AddScoped<DomiciliacionJob>();
     myBuilder.Services.AddHttpContextAccessor();
+    myBuilder.Services.AddScoped<IDomiciliacionService, DomiciliacionService>();
+    myBuilder.Services.AddScoped<IDomiciliacionRepository, DomiciliacionRepository>();
+
     
     // Quartz (domiciliaciones)
     myBuilder.Services.AddQuartz(q =>

--- a/Banco_VivesBank/Test/Movimientos/Repositories/DomiciliacionRepositoryTest.cs
+++ b/Banco_VivesBank/Test/Movimientos/Repositories/DomiciliacionRepositoryTest.cs
@@ -1,0 +1,265 @@
+﻿using Banco_VivesBank.Movimientos.Database;
+using Banco_VivesBank.Movimientos.Models;
+using Banco_VivesBank.Movimientos.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using Testcontainers.MongoDb;
+
+namespace Test.Movimientos.Repositories;
+
+[TestFixture]
+[TestOf(typeof(DomiciliacionRepository))]
+public class DomiciliacionRepositoryTest
+{
+
+private MongoDbContainer _mongoDbContainer;
+    private IDomiciliacionRepository _repository;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        _mongoDbContainer = new MongoDbBuilder()
+            .WithImage("mongo:4.4")
+            .WithPortBinding(27017, true)
+            .Build();
+
+        await _mongoDbContainer.StartAsync();
+
+        var mongoConfig = Options.Create(new MovimientosMongoConfig
+        {
+            ConnectionString = _mongoDbContainer.GetConnectionString(),
+            DatabaseName = "testdb",
+            DomiciliacionesCollectionName = "Domiciliaciones"
+        });
+
+        _repository = new DomiciliacionRepository(mongoConfig, NullLogger<DomiciliacionRepository>.Instance);
+    }
+
+    [TearDown] // Se ejecuta UNA VEZ después de todos los tests
+    public async Task TearDown()
+    {
+            await _mongoDbContainer.StopAsync(); // Detiene el contenedor
+            await _mongoDbContainer.DisposeAsync(); // Libera los recursos
+    }
+
+    [Test]
+    public async Task GetAllDomiciliaciones()
+    {
+        var domiciliacion = new Domiciliacion
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            Guid = Guid.NewGuid().ToString(),
+            ClienteGuid = Guid.NewGuid().ToString(),
+            Acreedor = "Acreedor Test",
+            IbanCliente = "ES9121000418450200051332",
+            IbanEmpresa = "ES6621000418401234567891",
+            Importe = 100
+        };
+        await _repository.AddDomiciliacionAsync(domiciliacion);
+        var domiciliaciones = await _repository.GetAllDomiciliacionesAsync();
+
+        Assert.That(domiciliaciones, Is.Not.Empty);
+        Assert.That(domiciliaciones.First().Guid, Is.EqualTo(domiciliacion.Guid));
+        Assert.That(domiciliaciones.Count(), Is.EqualTo(1));
+    }
+    [Test]
+    public async Task GetAllDomiciliacionesActivasAsync()
+    {
+        var domiciliacion = new Domiciliacion
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            Guid = Guid.NewGuid().ToString(),
+            ClienteGuid = Guid.NewGuid().ToString(),
+            Activa = true,
+            Acreedor = "Acreedor Test",
+            IbanCliente = "ES9121000418450200051332",
+            IbanEmpresa = "ES6621000418401234567891",
+            Importe = 100
+        };
+        await _repository.AddDomiciliacionAsync(domiciliacion);
+        var domiciliaciones = await _repository.GetAllDomiciliacionesActivasAsync();
+
+        Assert.That(domiciliaciones, Is.Not.Empty);
+        Assert.That(domiciliaciones.First().Guid, Is.EqualTo(domiciliacion.Guid));
+        Assert.That(domiciliaciones.Count(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GetDomiciliacionByIdAsync()
+    {
+        var domiciliacion = new Domiciliacion
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            Guid = Guid.NewGuid().ToString(),
+            ClienteGuid = Guid.NewGuid().ToString(),
+            Acreedor = "Acreedor Test",
+            IbanCliente = "ES9121000418450200051332",
+            IbanEmpresa = "ES6621000418401234567891",
+            Importe = 100
+        };
+        await _repository.AddDomiciliacionAsync(domiciliacion);
+        var domiciliacionById = await _repository.GetDomiciliacionByIdAsync(domiciliacion.Id);
+
+        Assert.That(domiciliacionById, Is.Not.Null);
+        Assert.That(domiciliacionById.Guid, Is.EqualTo(domiciliacion.Guid));
+
+    }
+    [Test]
+    public async Task GetDomiciliacionByIdAsync_NotFound()
+    {
+        var result = await _repository.GetDomiciliacionByIdAsync(ObjectId.GenerateNewId().ToString());
+        Assert.That(result, Is.Null);
+    }
+    
+    [Test]
+    public async Task GetDomiciliacionByGuidAsync()
+    {
+        var domiciliacion = new Domiciliacion
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            Guid = Guid.NewGuid().ToString(),
+            ClienteGuid = Guid.NewGuid().ToString(),
+            Acreedor = "Acreedor Test",
+            IbanCliente = "ES9121000418450200051332",
+            IbanEmpresa = "ES6621000418401234567891",
+            Importe = 100
+        };
+        await _repository.AddDomiciliacionAsync(domiciliacion);
+        var domiciliacionByGuid = await _repository.GetDomiciliacionByGuidAsync(domiciliacion.Guid);
+
+        Assert.That(domiciliacionByGuid, Is.Not.Null);
+        Assert.That(domiciliacionByGuid.Guid, Is.EqualTo(domiciliacion.Guid));
+
+    }
+    [Test]
+    public async Task GetDomiciliacionByGuidAsync_NotFound()
+    {
+        var result = await _repository.GetDomiciliacionByGuidAsync(Guid.NewGuid().ToString());
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task AddDomiciliacionAsync()
+    {
+        var domiciliacion = new Domiciliacion
+        {
+            Guid = Guid.NewGuid().ToString(),
+            ClienteGuid = Guid.NewGuid().ToString(),
+            Acreedor = "Acreedor Test",
+            IbanCliente = "ES9121000418450200051332",
+            IbanEmpresa = "ES6621000418401234567891",
+            Importe = 100
+        };
+        var result = await _repository.AddDomiciliacionAsync(domiciliacion);
+
+        Assert.That(result.Id, Is.Not.Null);
+        Assert.That(result.Guid, Is.Not.Null);
+        Assert.That(result.ClienteGuid, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task UpdateDomiciliacionAsync()
+    {
+        var domiciliacion = new Domiciliacion
+        {
+            Guid = Guid.NewGuid().ToString(),
+            ClienteGuid = Guid.NewGuid().ToString(),
+            Acreedor = "Acreedor Test",
+            IbanCliente = "ES9121000418450200051332",
+            IbanEmpresa = "ES6621000418401234567891",
+            Importe = 100
+        };
+        await _repository.AddDomiciliacionAsync(domiciliacion);
+        domiciliacion.Guid = "Nueva descripcion";
+        var result = await _repository.UpdateDomiciliacionAsync(domiciliacion.Id, domiciliacion);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Guid, Is.EqualTo("Nueva descripcion"));
+    }
+    
+    [Test]
+    public async Task UpdateDomiciliacionesAsync_NotFund()
+    {
+        var domiciliacion = new Domiciliacion
+        {
+            Guid = Guid.NewGuid().ToString(),
+            ClienteGuid = Guid.NewGuid().ToString(),
+            Acreedor = "Acreedor Test",
+            IbanCliente = "ES9121000418450200051332",
+            IbanEmpresa = "ES6621000418401234567891",
+            Importe = 100
+        };
+        var result = await _repository.UpdateDomiciliacionAsync(ObjectId.GenerateNewId().ToString(), domiciliacion);
+        Assert.That(result, Is.Null);
+    }
+    
+    [Test]
+    public async Task DeleteDomiciliacionAsync_NotFound()
+    {
+        var result = await _repository.DeleteDomiciliacionAsync(ObjectId.GenerateNewId().ToString());
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task DeleteDomiciliacionAsync()
+    {
+        var domiciliacion = new Domiciliacion
+        {
+            Guid = Guid.NewGuid().ToString(),
+            ClienteGuid = Guid.NewGuid().ToString(),
+            Acreedor = "Acreedor Test",
+            IbanCliente = "ES9121000418450200051332",
+            IbanEmpresa = "ES6621000418401234567891",
+            Importe = 100
+        };
+        await _repository.AddDomiciliacionAsync(domiciliacion);
+        var result = await _repository.DeleteDomiciliacionAsync(domiciliacion.Id);
+
+        Assert.That(result, Is.Not.Null);
+        
+    }
+    
+    [Test]
+    public async Task GetDomiciliacionesActivasByClienteGiudAsync()
+    {
+        var domiciliacion = new Domiciliacion
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            Guid = Guid.NewGuid().ToString(),
+            ClienteGuid = Guid.NewGuid().ToString(),
+            Activa = true,
+            Acreedor = "Acreedor Test",
+            IbanCliente = "ES9121000418450200051332",
+            IbanEmpresa = "ES6621000418401234567891",
+            Importe = 100
+        };
+        await _repository.AddDomiciliacionAsync(domiciliacion);
+        var domiciliaciones = await _repository.GetDomiciliacionesActivasByClienteGiudAsync(domiciliacion.ClienteGuid);
+
+        Assert.That(domiciliaciones, Is.Not.Empty);
+        Assert.That(domiciliaciones.First().Guid, Is.EqualTo(domiciliacion.Guid));
+        Assert.That(domiciliaciones.Count(), Is.EqualTo(1));
+    }
+    [Test]
+    public async Task GetDomiciliacionByClientGuidAsync()
+    {
+        var domiciliacion = new Domiciliacion
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            Guid = Guid.NewGuid().ToString(),
+            ClienteGuid = Guid.NewGuid().ToString(),
+            Activa = false,
+            Acreedor = "Acreedor Test",
+            IbanCliente = "ES9121000418450200051332",
+            IbanEmpresa = "ES6621000418401234567891",
+            Importe = 100
+        };
+        await _repository.AddDomiciliacionAsync(domiciliacion);
+        var domiciliaciones = await _repository.GetDomiciliacionesByClientGuidAsync(domiciliacion.ClienteGuid);
+
+        Assert.That(domiciliaciones, Is.Not.Empty);
+        Assert.That(domiciliaciones.First().Guid, Is.EqualTo(domiciliacion.Guid));
+        Assert.That(domiciliaciones.Count(), Is.EqualTo(1));
+    }
+}


### PR DESCRIPTION
Actualmente, desde los servicios se accede directamente a la base de datos. Nos hemos centrado en el servicio de Domiciliaciones como ejemplo, pero este planteamiento se repite en otros servicios. 

Se ha creado un repositorio que acceda a la base de datos como capa intermedia entre el servicio y la propia base de datos. Se ha definido un interfaz que debe implementar el repositorio, y ese interfaz es el que se inyecta al servicio.

Se ha testeado el nuevo repositorio mediante test containers y se han adaptado los tests ya existentes del servicio de Domiciliaciones. 

La finalidad es reducir el código repetitivo y el acoplamiento:
El servicio al estar directamente acoplado a la base de datos, en este caso MongoDB, requiere de modificaciones si decidimos cambiar a otra base de datos. 

Los tests son mas complejos al no utilizar una abstracción que podamos mockear. 

El código es mas difícil de mantener ya que cualquier cambio en la base de datos, implica una modificación de nuestra lógica de negocio en el servicio.
